### PR TITLE
First pass done by JJ

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,13 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
-
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Lenovo CNOS Cookbook
 
 ## Overview
-The cnos cookbook provides a set of recipes and resources for managing Lenovo 
-switches. The cookbook provides resources to upload images, upload/download 
-configurations and VLAN provisioning. The recipes use the CNOS Ruby APIs 
-(Ruby GEM) to communicate with the switch OS and configure them. 
+The cnos cookbook provides a set of recipes and resources for managing Lenovo
+switches. The cookbook provides resources to upload images, upload/download
+configurations and VLAN provisioning. The recipes use the CNOS Ruby APIs
+(Ruby GEM) to communicate with the switch OS and configure them.
 
 ## Recipes
+
+TODO: This section really isn't needed, but you can keep it if you want.
 Below is the list of the recipes provided part of the CNOS cookbook.
 
 1. configUpload
-This recipe uploads configuration to the switches. 
+This recipe uploads configuration to the switches.
 
 2. configDownload
 This recipe downloads configuration to the switches. The same configuration
@@ -23,7 +25,7 @@ This recipe upload new OS image to the switch.
 This recipe manages the VLAN (create/update/delete) provisiong on the switch.
 
 5. vlanIntf
-This recipe provides the management of VLAN properties for ethernet and 
+This recipe provides the management of VLAN properties for ethernet and
 port-channel interfaces.
 
 6. ipIntf
@@ -36,8 +38,8 @@ This recipe provides the management of IP interfaces.
 
 ## Running the cookbook
 1. Install chef-client on the node
-2. Install Lenovo CNOS Ruby GEM in the same node(or include in default recipe).
-3. Create switch.yml for each Lenovo device to be configured using the work 
+2. Install Lenovo CNOS Ruby GEM in the same node(or include in default recipe). # TODO: Please remove the gem from this cookbook, either publish to rubygems or something else. Binaries aren't supposed to be in cookbooks, it causes long term issues
+3. Create switch.yml for each Lenovo device to be configured using the work
    station, see below example file
 ```
 transport : 'http' #http or https
@@ -46,13 +48,17 @@ ip : 'switch ip address' #Switch IP address
 user : '<user>' #Credentials
 password : '<password>' #Credentials
 ```
-4. Add required recipe to node run-list 
+4. Add required recipe to node run-list
 5. Run chef-client on node
 6. Upload to the run-list of the chef-server and configure the devices
 
+## TODO
+add any testing or testing.md that is possible, if not, please
+state here and any ways you plan on setting up testing for this cookbook
+
 
 ## Contributors
-  * Lenovo DCG Networking, Lenovo 
+  * Lenovo DCG Networking, Lenovo
 
 ## License
 Apache 2.0, See LICENSE file

--- a/files/switch.yml
+++ b/files/switch.yml
@@ -1,16 +1,16 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 transport : 'http' #http or https
 port : '8090' #8090 or 443

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,11 +3,12 @@ maintainer       'Lenovo'
 maintainer_email 'cbhagavathip@lenovo.com'
 license          'Apache v2.0'
 description      'Implements an recipes for managing network resources on Lenovo switches'
-version          '1.0'
+version          '1.0' # TODO: we suggest semver here
 
 
+# TODO: all the lines with "this will fail" not to mention "why are the recipes declared here? Where did you get that from?
 recipe "configUpload"
-This receipe uploads configuration to the switches. 
+This receipe uploads configuration to the switches.
 
 recipe "configDownload"
 This receipe downloads configuration to the switches. The same configuration can be edited/modified and uploaded back using the configUpload recipe
@@ -20,8 +21,8 @@ This receipe manages the VLAN (create/delete) provisiong on the switch.
 
 recipe "vlan_intf"
 This receipe provides the management of VLAN properties for ethernet and port-channel interfaces.
-                 
+
 recipe "ip_intf"
 This receipe provides the management of IP interfaces .
 
-
+# TODO: add issues and source line to the metadata

--- a/recipes/configDownload.rb
+++ b/recipes/configDownload.rb
@@ -1,29 +1,29 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Cookbook : cnos
 # Recipe   : configDownload
 # Config files stored in chef-repo/cookbooks/cnos/files
 
+# TODO: you might want to put this in the README instead and not have this recipe here.
 
-#Download Config as running config from TFTP server
+# Download Config as running config from TFTP server
 cnos_swConfig 'config' do
-	file 'switch.yml'
-	type 'download'
-	protocol 'tftp'
-	serverip '192.168.1.1'
-	srcfile 'switch.conf'
-	dstfile 'running_config'
-	vrf_name 'management'
+  file 'switch.yml'
+  type 'download'
+  protocol 'tftp' # TODO: this should be an attribute, assuming you can have something other then tftp
+  serverip '192.168.1.1' # TODO: this should be an attribute
+  srcfile 'switch.conf' # TODO: this should be an attribute
+  dstfile 'running_config'
+  vrf_name 'management'
 end
-

--- a/recipes/configUpload.rb
+++ b/recipes/configUpload.rb
@@ -1,28 +1,29 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Cookbook : cnos
 # Recipe   : configUpload
 # Config files stored in chef-repo/cookbooks/cnos/files
 
-#Upload Config as running config to TFTP server
-cnos_swConfig 'config' do
-	file 'switch.yml'
-	type 'upload'
-	protocol 'tftp'
-	serverip '192.168.1.1'
-	srcfile 'running_config'
-	dstfile 'switch.conf'
-	vrf_name 'management'
-end
+# TODO: you might want to put this in the README instead and not have this recipe here.
 
+# Upload Config as running config to TFTP server
+cnos_swConfig 'config' do
+  file 'switch.yml'
+  type 'upload'
+  protocol 'tftp' # TODO: this should be an attribute, assuming you can have something other then tftp
+  serverip '192.168.1.1' # TODO: this should be an attribute
+  srcfile 'running_config' # TODO: this should be an attribute
+  dstfile 'switch.conf'
+  vrf_name 'management'
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,35 +1,36 @@
 ##
 ## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
 ##       http://www.apache.org/licenses/LICENSE-2.0
 ##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
+## See the License for the specific language governing permissions and
 ## limitations under the License.
 ##
 # Cookbook:: cnos
 # Recipe:: default
 
+# TODO: you should put a guard around this for non debian based OSes. Or add to the readme that only Debian based operating systems are supported
 
-#Upgrade client machine
-execute "update-upgrade" do
-  command "apt-get update && apt-get upgrade -y"
+# Upgrade client machine
+execute 'update-upgrade' do
+  command 'apt-get update && apt-get upgrade -y'
   action :run
 end
 
-#Install rest-client
+# Install rest-client
 chef_gem 'rest-client' do
-        action :install
+  action :install
 end
 require 'rest-client'
 
-#Install LenovoCheflib
+# TODO: you should really push this to rubygems
+# Install LenovoCheflib
 chef_gem 'LenovoCheflib' do
-	action :install
+  action :install
 end
 require 'LenovoCheflib'
-

--- a/recipes/imgDownload.rb
+++ b/recipes/imgDownload.rb
@@ -1,37 +1,38 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Cookbook : cnos
 # Recipe   : imgDownload
 # Config files stored in chef-repo/cookbooks/cnos/files
 
-#transfer Config files for switches to client
+# TODO: you can't assume the username chef will be here. You should figure out a way to transfer this file more dynamically
+# transfer Config files for switches to client
 cookbook_file '/home/chef/switch.yml' do
-        source 'switch.yml'
-        action :create
+  source 'switch.yml'
+  action :create
 end
 
-#Download Image from TFTP server
+# Download Image from TFTP server
 cnos_downloadImage 'image' do
-	file     'switch.yml'
-	protocol 'tftp'
-	serverip '192.168.1.1'
-	srcfile  'G8296-CNOS-10.4.2.0.img'	
-	imgtype  'all'
-	vrf_name 'management'
+  file     'switch.yml'
+  protocol 'tftp' # TODO: this should be an attribute, assuming you can have something other then tftp
+  serverip '192.168.1.1' # TODO: this should be an attribute
+  srcfile  'G8296-CNOS-10.4.2.0.img'
+  imgtype  'all'
+  vrf_name 'management'
 end
 
-#Reset the switch
+# Reset the switch
 cnos_resetSwitch 'reset' do
-	file     'switch.yml'
+  file     'switch.yml'
 end

--- a/recipes/ipIntf.rb
+++ b/recipes/ipIntf.rb
@@ -1,28 +1,30 @@
 ##
 ## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
 ##       http://www.apache.org/licenses/LICENSE-2.0
 ##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
+## See the License for the specific language governing permissions and
 ## limitations under the License.
 ##
 # Cookbook : cnos
 # Recipe   : ip_intf
 # Config files stored in chef-repo/cookbooks/cnos/files
 
-#Configure IP interface on switch
+# TODO: these all should be attributes so you can over ride them
+
+# Configure IP interface on switch
 cnos_ipIntf '1' do
-	file 'switch.yml'
-	if_name 'Ethernet1/1'
-	bridge_port 'yes'
-	mtu '1500'
-	ip_addr '0.0.0.0'
-	ip_prefix_len 0
-	vrf_name 'default'
-	admin_state 'up'
+  file 'switch.yml'
+  if_name 'Ethernet1/1'
+  bridge_port 'yes'
+  mtu '1500'
+  ip_addr '0.0.0.0'
+  ip_prefix_len 0
+  vrf_name 'default'
+  admin_state 'up'
 end

--- a/recipes/vlan.rb
+++ b/recipes/vlan.rb
@@ -1,40 +1,42 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Cookbook : cnos
 # Recipe   : vlan
 # Config files stored in chef-repo/cookbooks/cnos/files
 
-#VLAN config for switch
+# TODO: these should be attributes, and also as examples in documentation not in the actual cookbook
+
+# VLAN config for switch
 cnos_vlan '21' do
-	file 'switch.yml'
-	vlan 21
-	vlan_name 'vlan21'
-	admin_state 'up'
-	type 'create'
+  file 'switch.yml'
+  vlan 21
+  vlan_name 'vlan21'
+  admin_state 'up'
+  type 'create'
 end
 
 cnos_vlan '29' do
-	file 'switch.yml'
-	vlan 29
-	vlan_name 'Vlan29'
-	admin_state 'up'
-	type 'create'
+  file 'switch.yml'
+  vlan 29
+  vlan_name 'Vlan29'
+  admin_state 'up'
+  type 'create'
 end
 
-#Delete VLAN
+# Delete VLAN
 cnos_vlan '21' do
-	action :delete
-	file 'switch.yml'
-	vlan 21
+  action :delete
+  file 'switch.yml'
+  vlan 21
 end

--- a/recipes/vlanIntf.rb
+++ b/recipes/vlanIntf.rb
@@ -1,34 +1,35 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Cookbook : cnos
 # Recipe   : vlan_intf
 # Config files stored in chef-repo/cookbooks/cnos/files
 
-#Config vlan for interface on switch
+# TODO: these should be examples in the documentation not here in this recipe
+
+# Config vlan for interface on switch
 cnos_vlanIntf 'Ethernet1/1' do
-	file 'switch.yml'
-	interface 'Ethernet1/1'
-	bridgeport_mode 'trunk'
-	pvid 1
-	vlans [20,21]
+  file 'switch.yml'
+  interface 'Ethernet1/1'
+  bridgeport_mode 'trunk'
+  pvid 1
+  vlans [20, 21]
 end
 
-
 cnos_vlanIntf 'Ethernet1/2' do
-	file 'switch.yml'
-	interface 'Ethernet1/2'
-	bridgeport_mode 'trunk'
-	pvid 1
-	vlans [20,21]
+  file 'switch.yml'
+  interface 'Ethernet1/2'
+  bridgeport_mode 'trunk'
+  pvid 1
+  vlans [20, 21]
 end

--- a/resources/downloadImage.rb
+++ b/resources/downloadImage.rb
@@ -1,16 +1,16 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 property :protocol, String
 property :serverip, String
@@ -25,15 +25,15 @@ property :file, String
 default_action :create
 
 begin
-	require 'LenovoCheflib/connect'
-	require 'LenovoCheflib/system'
+  require 'LenovoCheflib/connect'
+  require 'LenovoCheflib/system'
 rescue LoadError
-	Chef::Log.debug 'Failed to require rubygem'
-end 
+  Chef::Log.debug 'Failed to require rubygem'
+end
 
 # The resources downloads image from the TFTP server using tftp or sftp
 # Waits for the image to be downloaded and resets the switch
-# Example - cnos_downloadImage 'image' do
+ # Example - cnos_downloadImage 'image' do
 #        	file     '<config file>'
 #        	protocol 'tftp'
 #        	serverip '<IP ADDRESS>'
@@ -41,63 +41,69 @@ end
 #        	imgtype  'all'
 #        	vrf_name 'management'
 #	    end
- 
-action :create do		
-		filename = '/home/chef/' + file
-		switch = Connect.new(filename)
-		if protocol == 'sftp'
-			params = {"protocol" => protocol, "serverip" => serverip, "srcfile" => srcfile, 
-				"imgtype" => imgtype, "username" => username, "passwd" => passwd, "vrf_name" => vrf_name}
-        	        System.download_boot_img(switch, params)
-			sleeptime = 100
-			puts '\n'
-			while true do
-				resp = System.get_transfer_status(switch, "download", "image")
-				if resp['status'] == 'successful' or resp['status'] == 'failed'
-					break
-				else
-					Chef::Log.info "Image transfer status " + switch.getIp + " >>>> "  + resp['status']
-				end
-				sleep sleeptime
-				if sleeptime > 11
-					sleeptime = 10
-				end
-			end
-			if resp['status'] == 'successful'
-				puts "Transfer status >> " + resp['status']
-				params = {"boot software" => "standby"}	
-				System.put_startup_sw(switch, params)
-			else
-				Chef::Log.info "Image transfer status " + switch.getIp + " >>>> "  + resp['status']
-			end
-				
-		end
-		
-		if protocol == 'tftp'
-			params = {"protocol" => protocol, "serverip" => serverip, "srcfile" => srcfile, 
-				"imgtype" => imgtype, "vrf_name" => vrf_name}
-        	        System.download_boot_img(switch, params)
-			sleeptime = 100
-			puts '\n'
-                        while true do
-                                resp = System.get_transfer_status(switch, "download", "image")
-                                if resp['status'] == 'successful' or resp['status'] == 'failed'
-                                        break
-				else
-					Chef::Log.info "Image transfer status " + switch.getIp + " >>>> "  + resp['status']
-                                end
-                                sleep sleeptime
-                                if sleeptime > 10
-                                        sleeptime = sleeptime/2
-                                end
-                        end
-                        if resp['status'] == 'successful'
-				puts "Transfer status >> " + resp['status']
-                                params = {"boot software" => "standby"}
-                                System.put_startup_sw(switch, params)
-			else
-				Chef::Log.info "Image transfer status " + switch.getIp + " >>>> "  + resp['status']
-                        end
 
-		end
+action :create do
+  filename = '/home/chef/' + file # TODO: having this hard coded for /home/chef is a bad idea, most users use _their_ home directory
+  switch = Connect.new(filename)
+  if protocol == 'sftp'
+    params = { 'protocol' => protocol,
+               'serverip' => serverip,
+               'srcfile' => srcfile,
+               'imgtype' => imgtype,
+               'username' => username,
+               'passwd' => passwd,
+               'vrf_name' => vrf_name }
+    System.download_boot_img(switch, params)
+    sleeptime = 100
+    puts '\n'
+    loop do
+      resp = System.get_transfer_status(switch, 'download', 'image')
+      if resp['status'] == 'successful' || resp['status'] == 'failed'
+        break
+      else
+        Chef::Log.info 'Image transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+      end
+      sleep sleeptime
+      sleeptime = 10 if sleeptime > 11
+    end
+    if resp['status'] == 'successful'
+      puts 'Transfer status >> ' + resp['status']
+      params = { 'boot software' => 'standby' }
+      System.put_startup_sw(switch, params)
+    else
+      Chef::Log.info 'Image transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+    end
+
+  end
+
+  if protocol == 'tftp'
+    params = { 'protocol' => protocol,
+               'serverip' => serverip,
+               'srcfile' => srcfile,
+               'imgtype' => imgtype,
+               'vrf_name' => vrf_name }
+    System.download_boot_img(switch, params)
+    sleeptime = 100
+    puts '\n'
+    loop do
+      resp = System.get_transfer_status(switch, 'download', 'image')
+      if resp['status'] == 'successful' || resp['status'] == 'failed'
+        break
+      else
+        Chef::Log.info 'Image transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+      end
+      sleep sleeptime
+      sleeptime /= 2 if sleeptime > 10
+    end
+    if resp['status'] == 'successful'
+      puts 'Transfer status >> ' + resp['status']
+      params = {
+        'boot software' => 'standby'
+      }
+      System.put_startup_sw(switch, params)
+    else
+      Chef::Log.info 'Image transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+    end
+
+  end
 end

--- a/resources/ipIntf.rb
+++ b/resources/ipIntf.rb
@@ -1,14 +1,14 @@
 ##
 ## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
 ##       http://www.apache.org/licenses/LICENSE-2.0
 ##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
+## See the License for the specific language governing permissions and
 ## limitations under the License.
 ##
 
@@ -25,11 +25,11 @@ property :ip_prefix_len, Integer
 default_action :create
 
 begin
-	require 'LenovoCheflib/connect'
-	require 'LenovoCheflib/ip_intf'
+  require 'LenovoCheflib/connect'
+  require 'LenovoCheflib/ip_intf'
 rescue LoadError
-	Chef::Log.debug 'Failed to require rubygem'
-end 
+  Chef::Log.debug 'Failed to require rubygem'
+end
 
 # The resource configures the IP interface for the switch
 # Example - cnos_ipIntf '1' do
@@ -44,9 +44,15 @@ end
 #	    end
 
 action :create do
-		filename = '/home/chef/' + file
-		switch = Connect.new(filename)
-		params = {"ip_addr" => ip_addr, "if_name" => if_name, "bridge_port" => bridge_port, "mtu" =>mtu, "vrf_name" => vrf_name, "admin_state" => admin_state, "ip_prefix_len" => ip_prefix_len}
-		resp = Ipintf.update_ip_prop_intf(switch, if_name, params)
-		puts resp
-	end
+  filename = '/home/chef/' + file  # TODO: having this hard coded for /home/chef is a bad idea, most users use _their_ home directory
+  switch = Connect.new(filename)
+  params = { 'ip_addr' => ip_addr,
+             'if_name' => if_name,
+             'bridge_port' => bridge_port,
+             'mtu' => mtu,
+             'vrf_name' => vrf_name,
+             'admin_state' => admin_state,
+             'ip_prefix_len' => ip_prefix_len }
+  resp = Ipintf.update_ip_prop_intf(switch, if_name, params)
+  puts resp
+end

--- a/resources/resetSwitch.rb
+++ b/resources/resetSwitch.rb
@@ -1,16 +1,16 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 property :file, String
 
@@ -18,24 +18,21 @@ property :file, String
 default_action :create
 
 begin
-	require 'LenovoCheflib/connect'
-	require 'LenovoCheflib/system'
+  require 'LenovoCheflib/connect'
+  require 'LenovoCheflib/system'
 rescue LoadError
-	Chef::Log.debug 'Failed to require rubygem'
-end 
+  Chef::Log.debug 'Failed to require rubygem'
+end
 
-# This resource is used to reset the switch after an image download 
+# This resource is used to reset the switch after an image download
 # Example :
 #	cnos_resetSwitch 'reset' do
 #		file     'switch.yml'
 #	end
 
 action :create do
-	filename = '/home/chef/' + file
-        switch = Connect.new(filename)
-        System.reset_switch(switch)
-	Chef::Log.info "\n\n>>>>>>>>>>>>>>>>>>>Reset Switch " + switch.getIp + " in progress<<<<<<<<<<<<<<<<<<<<<<"
+  filename = '/home/chef/' + file  # TODO: having this hard coded for /home/chef is a bad idea, most users use _their_ home directory
+  switch = Connect.new(filename)
+  System.reset_switch(switch)
+  Chef::Log.info "\n\n>>>>>>>>>>>>>>>>>>>Reset Switch " + switch.getIp + ' in progress<<<<<<<<<<<<<<<<<<<<<<'
 end
-
-
-

--- a/resources/swConfig.rb
+++ b/resources/swConfig.rb
@@ -1,16 +1,16 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 property :protocol, String
 property :serverip, String
@@ -22,17 +22,15 @@ property :vrf_name, String
 property :type, String
 property :file, String
 
-
 # Defaults to the first action
 default_action :create
 
 begin
-	require 'LenovoCheflib/connect'
-	require 'LenovoCheflib/system'
+  require 'LenovoCheflib/connect'
+  require 'LenovoCheflib/system'
 rescue LoadError
-	Chef::Log.debug 'Failed to require rubygem'
-end 
-
+  Chef::Log.debug 'Failed to require rubygem'
+end
 
 # The resources downloads/uploads switch config from the TFTP server using tftp or sftp
 # Example - cnos_swConfig 'config' do
@@ -46,78 +44,94 @@ end
 #	    end
 
 action :create do
-		filename = '/home/chef/' + file
-		switch = Connect.new(filename)
-		if type == "download"
-			if protocol == 'tftp' 
-				params = {"protocol" => protocol, "serverip" => serverip, "srcfile" => srcfile, 
-				"dstfile" => dstfile, "vrf_name" => vrf_name}
-                		System.download_sw_config(switch, params)
-				sleeptime = 5
-				puts '\n'
-				while true do
-					resp = System.get_transfer_status(switch, "download","running_config")
-					if resp['status'] == 'successful' or resp['status'] == 'failed'
-						break
-					else
-						Chef::Log.info "Config transfer status " + switch.getIp + " >>>> "  + resp['status']
-					end
-					sleep sleeptime
-				end
-				Chef::Log.info "Config transfer status " + switch.getIp + " >>>> "  + resp['status']
-			else  
-				params = {"protocol" => protocol, "serverip" => serverip, "srcfile" => srcfile,
-                                "dstfile" => dstfile,"username" => username, "passwd" => passwd,  "vrf_name" => vrf_name}
-                                System.download_sw_config(switch, params)
-				sleeptime = 5
-				puts '\n'
-				while true do
-					resp = System.get_transfer_status(switch,  "upload", "running_config")
-					if resp['status'] == 'successful' or resp['status'] == 'failed'
-						break
-					else
-						Chef::Log.info "Config transfer status " + switch.getIp + " >>>> "  + resp['status']
-					end
-					sleep sleeptime
-				end
-				Chef::Log.info "Config transfer status " + switch.getIp + " >>>> "  + resp['status']
-			end
-		end
+  filename = '/home/chef/' + file  # TODO: having this hard coded for /home/chef is a bad idea, most users use _their_ home directory
+  switch = Connect.new(filename)
+  if type == 'download'
+    if protocol == 'tftp'
+      params = { 'protocol' => protocol,
+                 'serverip' => serverip,
+                 'srcfile' => srcfile,
+                 'dstfile' => dstfile,
+                 'vrf_name' => vrf_name }
+      System.download_sw_config(switch, params)
+      sleeptime = 5
+      puts '\n'
+      loop do
+        resp = System.get_transfer_status(switch, 'download', 'running_config')
+        if resp['status'] == 'successful' || resp['status'] == 'failed'
+          break
+        else
+          Chef::Log.info 'Config transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+        end
+        sleep sleeptime
+      end
+      Chef::Log.info 'Config transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+    else
+      params = {
+        'protocol' => protocol,
+        'serverip' => serverip,
+        'srcfile' => srcfile,
+        'dstfile' => dstfile,
+        'username' => username,
+        'passwd' => passwd,
+        'vrf_name' => vrf_name }
+      System.download_sw_config(switch, params)
+      sleeptime = 5
+      puts '\n'
+      loop do
+        resp = System.get_transfer_status(switch, 'upload', 'running_config')
+        if resp['status'] == 'successful' || resp['status'] == 'failed'
+          break
+        else
+          Chef::Log.info 'Config transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+        end
+        sleep sleeptime
+      end
+      Chef::Log.info 'Config transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+    end
+  end
 
-
-		if type == 'upload'
-			if protocol == 'tftp' 
-				params = {"protocol" => protocol, "serverip" => serverip, "srcfile" => srcfile, 
-				"dstfile" => dstfile, "vrf_name" => vrf_name}
-                		System.upload_sw_config(switch, params)
-				sleeptime = 5
-				puts '\n'
-				while true do
-					resp = System.get_transfer_status(switch, "upload", "running_config")
-					if resp['status'] == 'successful' or resp['status'] == 'failed'
-						break
-					else
-						Chef::Log.info "Config transfer status " + switch.getIp + " >>>> "  + resp['status']
-					end
-					sleep sleeptime
-				end
-				Chef::Log.info "Config transfer status " + switch.getIp + " >>>> "  + resp['status']
-			else
-                                parrams = {"protocol" => protocol, "serverip" => serverip, "srcfile" => srcfile,
-                                "dstfile" => dstfile,"username" => username, "passwd" => passwd,  "vrf_name" => vrf_name}
-                                System.upload_sw_config(switch, params)
-				sleeptime = 5
-				puts '\n'
-				while true do
-					resp = System.get_transfer_status(switch, "upload", "running_config")
-					if resp['status'] == 'successful' or resp['status'] == 'failed'
-						break
-					else
-						Chef::Log.info "Config transfer status " + switch.getIp + " >>>> "  + resp['status']
-					end
-					sleep sleeptime
-				end
-				Chef::Log.info "Config transfer status " + switch.getIp + " >>>> "  + resp['status']
-                        end
-	 	end	
+  if type == 'upload'
+    if protocol == 'tftp'
+      params = { 'protocol' => protocol,
+                 'serverip' => serverip,
+                 'srcfile' => srcfile,
+                 'dstfile' => dstfile,
+                 'vrf_name' => vrf_name }
+      System.upload_sw_config(switch, params)
+      sleeptime = 5
+      puts '\n'
+      loop do
+        resp = System.get_transfer_status(switch, 'upload', 'running_config')
+        if resp['status'] == 'successful' || resp['status'] == 'failed'
+          break
+        else
+          Chef::Log.info 'Config transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+        end
+        sleep sleeptime
+      end
+      Chef::Log.info 'Config transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+    else
+      parrams = { 'protocol' => protocol,
+                  'serverip' => serverip,
+                  'srcfile' => srcfile,
+                  'dstfile' => dstfile,
+                  'username' => username,
+                  'passwd' => passwd,
+                  'vrf_name' => vrf_name }
+      System.upload_sw_config(switch, params)
+      sleeptime = 5
+      puts '\n'
+      loop do
+        resp = System.get_transfer_status(switch, 'upload', 'running_config')
+        if resp['status'] == 'successful' || resp['status'] == 'failed'
+          break
+        else
+          Chef::Log.info 'Config transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+        end
+        sleep sleeptime
+      end
+      Chef::Log.info 'Config transfer status ' + switch.getIp + ' >>>> ' + resp['status']
+    end
+  end
 end

--- a/resources/vlan.rb
+++ b/resources/vlan.rb
@@ -1,20 +1,20 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 property :vlan, Integer, name_property: true
 property :vlan_name, String
-property :admin_state,String
+property :admin_state, String
 property :file, String
 property :type, String
 
@@ -22,13 +22,11 @@ property :type, String
 default_action :create
 
 begin
-	require 'LenovoCheflib/connect'
-	require 'LenovoCheflib/vlan'
+  require 'LenovoCheflib/connect'
+  require 'LenovoCheflib/vlan'
 rescue LoadError
-	Chef::Log.debug 'Failed to require rubygem'
-end 
-
-
+  Chef::Log.debug 'Failed to require rubygem'
+end
 
 # This resource are used to create vlan, update and delete vlan
 # Example - cnos_vlan '21' do
@@ -39,21 +37,25 @@ end
 #		type 'create'
 #	    end
 action :create do
-	filename = '/home/chef/' + file
-	switch = Connect.new(filename)
-	if type == 'create'
-		params = {"vlan_name" => vlan_name, "vlan_id" => vlan, "admin_state" => admin_state}
-  		Vlan.create_vlan(switch, params)
-	end
-	if type == 'update'
-		params = {"vlan_name" => vlan_name, "vlan_id" => vlan, "admin_state" => admin_state}
-		Vlan.update_vlan(switch, params)
-	end
+  filename = '/home/chef/' + file # TODO: having this hard coded for /home/chef is a bad idea, most users use _their_ home directory
+  switch = Connect.new(filename)
+  if type == 'create'
+    params = { 'vlan_name' => vlan_name,
+               'vlan_id' => vlan,
+               'admin_state' => admin_state }
+    Vlan.create_vlan(switch, params)
+  end
+  if type == 'update'
+    params = { 'vlan_name' => vlan_name,
+               'vlan_id' => vlan,
+               'admin_state' => admin_state }
+    Vlan.update_vlan(switch, params)
+  end
 end
 
-#delete vlan
+# delete vlan
 action :delete do
-	filename = '/home/chef/' + file
-	switch = Connect.new(filename)
-	Vlan.delete_vlan(switch, vlan)
+  filename = '/home/chef/' + file
+  switch = Connect.new(filename)
+  Vlan.delete_vlan(switch, vlan)
 end

--- a/resources/vlanIntf.rb
+++ b/resources/vlanIntf.rb
@@ -1,16 +1,16 @@
-##
-## Copyright (C) 2017 Lenovo, Inc.
-## Licensed under the Apache License, Version 2.0 (the "License"); 
-## you may not use this file except in compliance with the License. 
-## You may obtain a copy of the License at 
-##       http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software 
-## distributed under the License is distributed on an "AS IS" BASIS, 
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and 
-## limitations under the License.
-##
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 property :file, String
 property :interface, String
@@ -22,12 +22,11 @@ property :vlans, Array
 default_action :create
 
 begin
-	require 'LenovoCheflib/connect'
-	require 'LenovoCheflib/vlan_intf'
+  require 'LenovoCheflib/connect'
+  require 'LenovoCheflib/vlan_intf'
 rescue LoadError
-	Chef::Log.debug 'Failed to require rubygem'
-end 
-
+  Chef::Log.debug 'Failed to require rubygem'
+end
 
 # Defaults to the first action
 default_action :create
@@ -45,12 +44,13 @@ default_action :create
 #           end
 
 action :create do
-		filename = '/home/chef/' + file
-		switch = Connect.new(filename)
-		params = {"if_name" => interface, "bridgeport_mode" => bridgeport_mode, "pvid" =>pvid, "vlans" => vlans}
-                resp = VlanIntf.update_vlan_intf(switch, interface, params)
-		Chef::Log.info "\n VLAN Interface Info  " 
-		puts resp
-        end
-
-
+  filename = '/home/chef/' + file # TODO: having this hard coded for /home/chef is a bad idea, most users use _their_ home directory
+  switch = Connect.new(filename)
+  params = { 'if_name' => interface,
+             'bridgeport_mode' => bridgeport_mode,
+             'pvid' => pvid,
+             'vlans' => vlans }
+  resp = VlanIntf.update_vlan_intf(switch, interface, params)
+  Chef::Log.info "\n VLAN Interface Info  "
+  puts resp
+end


### PR DESCRIPTION
- Ran rubocop, you should standardize on something like it and add the
  .rubocop.yml too
- Made comments with the TODO before the statement please address each
  of them
- The recipes all in all should be examples in the README or
  documentation, having them in the actual cookbook will confuse the end
  user
- Leverage attributes where you can, a lot of these values are hard
  coded which is bad for a public cookbook
- Publish the gem to Rubygems, do NOT ship it with this cookbook,
  binaries inside of cookbooks is a bad habit and pattern that can cause
  downstream issues to consumers

Signed-off-by: JJ Asghar <jj@chef.io>